### PR TITLE
feat: containerize Zora for integration testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+*.md
+!README.md
+.git
+.github
+specs
+tests/fixtures
+coverage
+.env*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,50 @@
+# Stage 1: Build frontend
+FROM node:20-alpine AS frontend
+WORKDIR /app/frontend
+COPY src/dashboard/frontend/package*.json ./
+RUN npm ci
+COPY src/dashboard/frontend/ ./
+RUN npm run build
+
+# Stage 2: Build backend
+FROM node:20-alpine AS backend
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src/ ./src/
+# Overlay built frontend into source tree before tsc
+COPY --from=frontend /app/frontend/dist ./src/dashboard/frontend/dist/
+RUN npx tsc
+
+# Stage 3: Runtime
+FROM node:20-alpine
+WORKDIR /app
+
+RUN apk add --no-cache curl
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY --from=backend /app/dist ./dist/
+COPY --from=frontend /app/frontend/dist ./dist/dashboard/frontend/dist/
+
+# Create Zora state directories
+RUN mkdir -p /root/.zora/workspace \
+             /root/.zora/memory/daily \
+             /root/.zora/memory/items \
+             /root/.zora/memory/categories \
+             /root/.zora/audit \
+             /root/.zora/state
+
+# Default config for container (can be overridden with volume mount)
+COPY docker/config.toml /root/.zora/config.toml
+COPY docker/policy.toml /root/.zora/policy.toml
+
+ENV ZORA_BIND_HOST=0.0.0.0
+EXPOSE 7070
+
+HEALTHCHECK --interval=15s --timeout=5s --retries=3 \
+  CMD curl -f http://localhost:7070/api/health || exit 1
+
+CMD ["node", "dist/cli/daemon.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  zora:
+    build: .
+    ports:
+      - "7070:7070"
+    volumes:
+      - zora-config:/root/.zora
+    environment:
+      - NODE_ENV=test
+      - ZORA_BIND_HOST=0.0.0.0
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:7070/api/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 3
+
+  # Integration test runner — runs after zora is healthy
+  test-runner:
+    build: .
+    depends_on:
+      zora:
+        condition: service_healthy
+    environment:
+      - ZORA_URL=http://zora:7070
+    entrypoint: ["node", "--test", "dist/tests/integration/"]
+    profiles:
+      - test
+
+volumes:
+  zora-config:

--- a/docker/config.toml
+++ b/docker/config.toml
@@ -1,0 +1,60 @@
+# Container test configuration — mock providers, no real AI calls
+
+[agent]
+name = "zora-container"
+workspace = "/root/.zora/workspace"
+max_parallel_jobs = 2
+default_timeout = "1h"
+heartbeat_interval = "15m"
+log_level = "debug"
+
+[agent.identity]
+soul_file = "/root/.zora/workspace/SOUL.md"
+
+[agent.resources]
+cpu_throttle_percent = 80
+memory_limit_mb = 512
+
+[[providers]]
+name = "claude"
+type = "claude-sdk"
+rank = 1
+capabilities = ["reasoning", "coding", "creative"]
+cost_tier = "included"
+enabled = false
+
+[[providers]]
+name = "gemini"
+type = "gemini-cli"
+rank = 2
+capabilities = ["search", "structured-data"]
+cost_tier = "included"
+enabled = false
+
+[routing]
+mode = "respect_ranking"
+
+[failover]
+enabled = true
+auto_handoff = true
+max_retries = 3
+
+[memory]
+long_term_file = "/root/.zora/memory/MEMORY.md"
+daily_notes_dir = "/root/.zora/memory/daily"
+items_dir = "/root/.zora/memory/items"
+categories_dir = "/root/.zora/memory/categories"
+
+[security]
+policy_file = "/root/.zora/policy.toml"
+audit_log = "/root/.zora/audit/audit.jsonl"
+audit_hash_chain = true
+leak_detection = true
+
+[steering]
+enabled = true
+dashboard_port = 7070
+poll_interval = "5s"
+
+[notifications]
+enabled = false

--- a/docker/policy.toml
+++ b/docker/policy.toml
@@ -1,0 +1,24 @@
+# Container test policy — permissive for integration testing
+
+[filesystem]
+allowed_paths = ["/root/.zora", "/tmp"]
+denied_paths = []
+resolve_symlinks = true
+follow_symlinks = false
+
+[shell]
+mode = "allowlist"
+allowed_commands = ["ls", "echo", "cat"]
+denied_commands = ["rm", "sudo"]
+split_chained_commands = true
+max_execution_time = "30s"
+
+[actions]
+reversible = ["write_file", "edit_file"]
+irreversible = []
+always_flag = []
+
+[network]
+allowed_domains = ["*"]
+denied_domains = []
+max_request_size = "10MB"

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -94,6 +94,7 @@ async function main() {
     steeringManager: orchestrator.steeringManager,
     authMonitor: orchestrator.authMonitor,
     port: config.steering.dashboard_port ?? 7070,
+    host: process.env.ZORA_BIND_HOST,
   });
   await dashboard.start();
 

--- a/src/cli/init-command.ts
+++ b/src/cli/init-command.ts
@@ -12,7 +12,7 @@ import fs from 'node:fs';
 import * as clack from '@clack/prompts';
 import { stringify as stringifyTOML } from 'smol-toml';
 import { parse as parseTOML } from 'smol-toml';
-import { PRESETS, TOOL_STACKS, PRESET_DESCRIPTIONS } from './presets.js';
+import { PRESETS, TOOL_STACKS } from './presets.js';
 import { runDoctorChecks } from './doctor.js';
 import type { DoctorResult } from './doctor.js';
 import type { PresetName } from './presets.js';

--- a/src/dashboard/server.ts
+++ b/src/dashboard/server.ts
@@ -24,6 +24,7 @@ export interface DashboardOptions {
   steeringManager: SteeringManager;
   authMonitor: AuthMonitor;
   port?: number;
+  host?: string;
 }
 
 export class DashboardServer {
@@ -208,9 +209,10 @@ export class DashboardServer {
    */
   async start(): Promise<void> {
     const port = this._options.port ?? 7070;
+    const host = this._options.host ?? '127.0.0.1';
     return new Promise((resolve) => {
-      this._server = this._app.listen(port, '127.0.0.1', () => {
-        console.log(`[Dashboard] Zora Tactical Interface active at http://localhost:${port}`);
+      this._server = this._app.listen(port, host, () => {
+        console.log(`[Dashboard] Zora Tactical Interface active at http://${host}:${port}`);
         resolve();
       });
     });


### PR DESCRIPTION
## **User description**
## Summary
- Multi-stage Dockerfile: frontend build → backend build → alpine runtime
- docker-compose.yml with health checks and test runner profile
- Configurable bind host via `ZORA_BIND_HOST` env var (defaults to `0.0.0.0` in container, `127.0.0.1` locally)
- Container config with providers disabled for mock testing
- Fix unused `PRESET_DESCRIPTIONS` import that broke `tsc` build

## How to test
```bash
docker compose build
docker compose up zora
# Dashboard at http://localhost:7070
# Integration tests: docker compose --profile test up test-runner
```

## Test plan
- [ ] `docker compose build` succeeds
- [ ] Container starts and healthcheck passes
- [ ] Dashboard loads at http://localhost:7070
- [ ] `/api/health` returns valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Docker containerization support for streamlined deployment
  * Introduced Docker Compose configuration for integrated local development and testing environments
  * Added container configuration and security policy files for consistent runtime behavior
  * Enhanced dashboard server with flexible host binding configuration for various deployment scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Add containerized runtime and dockerized integration test setup

### What Changed
- Introduces a Dockerfile and docker-compose setup so Zora can run inside a container and expose the dashboard on port 7070
- Dashboard host becomes configurable via ZORA_BIND_HOST so the server can bind to 0.0.0.0 inside containers and remain localhost locally
- Adds container-only default config and policy that disable real AI providers and limit capabilities for safe integration tests
- Adds a healthcheck and a test-runner service in docker-compose that waits for Zora to be healthy before running integration tests
- Removes an unused import that previously broke TypeScript compilation

### Impact
`✅ Dashboard accessible from other hosts when containerized`
`✅ Run integration tests reliably inside CI via docker compose`
`✅ Fewer accidental external AI calls during containerized tests`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
