### PR TITLE
fix: add Playwright test with CSS-transform-aware locators

### DIFF
--- a/tests/unit/dashboard/dashboard-synthetic.test.ts
+++ b/tests/unit/dashboard/dashboard-synthetic.test.ts
@@ -1,0 +1,61 @@
+import { test, expect } from '@playwright/test';
+import { DashboardServer } from '../../../src/dashboard/server.js';
+import { ExecutionLoop } from '../../../src/orchestrator/execution-loop.js';
+import { SessionManager } from '../../../src/orchestrator/session-manager.js';
+import { SteeringManager } from '../../../src/steering/steering-manager.js';
+import { AuthMonitor } from '../../../src/orchestrator/auth-monitor.js';
+import { MockProvider } from '../../fixtures/mock-provider.js';
+import { PolicyEngine } from '../../../src/security/policy-engine.js';
+import { NotificationTools } from '../../../src/tools/notifications.js';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs/promises';
+
+test.describe('Page Load Journey', () => {
+  let server: DashboardServer;
+  const testDir = path.join(os.tmpdir(), 'zora-dashboard-synthetic-test');
+  const port = 7072;
+
+  test.beforeAll(async () => {
+    await fs.mkdir(testDir, { recursive: true });
+
+    const provider = new MockProvider();
+    const engine = new PolicyEngine({
+      filesystem: { allowed_paths: [], denied_paths: [], resolve_symlinks: true, follow_symlinks: false },
+      shell: { mode: 'deny_all', allowed_commands: [], denied_commands: [], split_chained_commands: true, max_execution_time: '1m' },
+      actions: { reversible: [], irreversible: [], always_flag: [] },
+      network: { allowed_domains: [], denied_domains: [], max_request_size: '1mb' },
+    });
+    const sessionManager = new SessionManager(testDir);
+    const steeringManager = new SteeringManager(testDir);
+    const notifications = new NotificationTools();
+    const authMonitor = new AuthMonitor({ providers: [provider], notifications });
+    const loop = new ExecutionLoop({ provider, engine, sessionManager, steeringManager });
+
+    server = new DashboardServer({ loop, sessionManager, steeringManager, authMonitor, port });
+    await server.start();
+  });
+
+  test.afterAll(async () => {
+    server.stop();
+  });
+
+  test('footer displays version info', async ({ page }) => {
+    await page.goto(`http://localhost:${port}`);
+
+    // Wait for page to load
+    await expect(page).toHaveTitle(/Zora/);
+
+    // Use getByText with case-insensitive matching to handle CSS text-transform
+    // The footer contains "Zora v0.6.0" and "Dashboard" but they're rendered as uppercase
+    const footer = page.locator('div.text-\\[10px\\].font-data.text-white\\/40.uppercase.tracking-widest').last();
+
+    // Check footer is visible
+    await expect(footer).toBeVisible();
+
+    // Verify the text content (checking actual DOM text, not rendered uppercase)
+    const footerText = await footer.textContent();
+    expect(footerText).toContain('Zora v0.6.0');
+    expect(footerText).toContain('Dashboard');
+  });
+});


### PR DESCRIPTION
## **User description**
Creates dashboard-synthetic.test.ts with proper locators that handle CSS text-transform: uppercase. Uses CSS class selector and textContent assertions instead of text= locators that fail with transformed text.

Fixes #39

Generated with [Claude Code](https://claude.ai/code)


___

## **CodeAnt-AI Description**
Add Playwright test that tolerates CSS text-transform and verifies footer version

### What Changed
- Adds a Playwright end-to-end test that starts the dashboard server, navigates to the page, and verifies the footer is visible
- Locates the footer using a CSS class selector and checks the element's DOM text content (not rendered case) so assertions succeed despite CSS text-transform: uppercase
- Confirms the footer contains the specific version string ("Zora v0.6.0") and the word "Dashboard"

### Impact
`✅ Fewer Playwright locator failures caused by CSS text-transform`
`✅ Clearer, reliable footer version checks in tests`
`✅ Faster diagnosis of UI regressions related to footer rendering`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
