### PR TITLE
fix(security): wire capability-token enforcement into submitTask [SEC-10]

### DIFF
--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -518,25 +518,7 @@ export class Orchestrator {
       maxTurns: options.maxTurns,
       errorBudget,
       customTools,
-      canUseTool: (() => {
-        const policyCanUseTool = this._policyEngine.createCanUseTool();
-        return async (tool: string, input: Record<string, unknown>, options: { signal: unknown }) => {
-          const token = this._activeTokens.get(jobId);
-          if (token) {
-            const pathArg = input['path'] as string | undefined;
-            if (pathArg) {
-              const capResult = enforceCapability(token, { type: 'path', target: pathArg });
-              if (!capResult.allowed) return { behavior: 'deny' as const, message: capResult.reason ?? 'Path denied by capability token' };
-            }
-            const cmdArg = input['command'] as string | undefined;
-            if (cmdArg) {
-              const capResult = enforceCapability(token, { type: 'command', target: cmdArg });
-              if (!capResult.allowed) return { behavior: 'deny' as const, message: capResult.reason ?? 'Command denied by capability token' };
-            }
-          }
-          return policyCanUseTool(tool, input, options);
-        };
-      })(),
+      canUseTool: this._buildTokenAwareCanUseTool(jobId),
     };
 
     // ORCH-12: Run onTaskStart hooks (can modify context before routing)
@@ -1174,25 +1156,7 @@ export class Orchestrator {
 
     const resumeContext: TaskContext = {
       ...context,
-      canUseTool: (() => {
-        const policyCanUseTool = this._policyEngine.createCanUseTool();
-        return async (tool: string, input: Record<string, unknown>, options: { signal: unknown }) => {
-          const token = this._activeTokens.get(resumeJobId);
-          if (token) {
-            const pathArg = input['path'] as string | undefined;
-            if (pathArg) {
-              const capResult = enforceCapability(token, { type: 'path', target: pathArg });
-              if (!capResult.allowed) return { behavior: 'deny' as const, message: capResult.reason ?? 'Path denied by capability token' };
-            }
-            const cmdArg = input['command'] as string | undefined;
-            if (cmdArg) {
-              const capResult = enforceCapability(token, { type: 'command', target: cmdArg });
-              if (!capResult.allowed) return { behavior: 'deny' as const, message: capResult.reason ?? 'Command denied by capability token' };
-            }
-          }
-          return policyCanUseTool(tool, input, options);
-        };
-      })(),
+      canUseTool: this._buildTokenAwareCanUseTool(resumeJobId),
     };
 
     // Route to provider using the preserved classification (no re-classification)
@@ -1427,6 +1391,31 @@ export class Orchestrator {
     );
 
     return [...permissionTools, ...memoryTools, recallContextTool, ...skillTools, planWorkflowTool];
+  }
+
+  /**
+   * SEC-10: Builds a token-aware canUseTool function that enforces capability
+   * token restrictions on path and command inputs before delegating to the
+   * policy engine. Call this once per job to get a closure bound to jobId.
+   */
+  private _buildTokenAwareCanUseTool(jobId: string): (tool: string, input: Record<string, unknown>, options: { signal: unknown }) => Promise<{ behavior: 'allow' | 'deny'; message?: string; updatedInput?: Record<string, unknown> }> {
+    const policyCanUseTool = this._policyEngine.createCanUseTool();
+    return async (tool: string, input: Record<string, unknown>, options: { signal: unknown }) => {
+      const token = this._activeTokens.get(jobId);
+      if (token) {
+        const pathArg = input['path'] as string | undefined;
+        if (pathArg) {
+          const capResult = enforceCapability(token, { type: 'path', target: pathArg });
+          if (!capResult.allowed) return { behavior: 'deny' as const, message: capResult.reason ?? 'Path denied by capability token' };
+        }
+        const cmdArg = input['command'] as string | undefined;
+        if (cmdArg) {
+          const capResult = enforceCapability(token, { type: 'command', target: cmdArg });
+          if (!capResult.allowed) return { behavior: 'deny' as const, message: capResult.reason ?? 'Command denied by capability token' };
+        }
+      }
+      return policyCanUseTool(tool, input, options);
+    };
   }
 
   /**


### PR DESCRIPTION
## **User description**
## Summary

- Imports `createCapabilityToken` and `enforceCapability` from `security/capability-tokens.ts`
- Adds `_activeTokens: Map<string, WorkerCapabilityToken>` field to Orchestrator
- Creates a scoped token per job in `submitTask()` and `_resumeTask()`
- Wraps `policyEngine.createCanUseTool()` with a token enforcement layer that checks `path` and `command` inputs before delegating to policy
- Cleans up token in `finally` block after task completion

## Why

`createCapabilityToken()` and `enforceCapability()` were written, tested in isolation, and re-exported from the security barrel — but never called from the runtime path. Worker isolation (documented in the spec) was not enforced.

## Test plan
- [ ] TypeScript compiles cleanly (no new errors introduced — pre-existing node/@types issues unchanged)
- [ ] `npm test` passes
- [ ] Manual: task with allowed path proceeds normally
- [ ] Manual: task attempting denied path is blocked at canUseTool gate

Closes SEC-10 from `gaps/DEAD_MODULE_INTEGRATION.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Enforce per-task capability tokens to block disallowed tool actions

### What Changed
- A scoped capability token is created for each job and used whenever a task asks to use a tool; tool requests that reference a file path or shell command are checked against that token before policy checks
- When a path or command is disallowed by the token, the tool call is immediately denied with a clear deny outcome and message instead of proceeding to policy evaluation
- Tokens are created for resumed tasks as well and are always removed after the task finishes or fails, preventing stale tokens from persisting

### Impact
`✅ Fewer unauthorized tool executions`
`✅ Clearer deny responses when path/command use is blocked`
`✅ Worker capabilities limited to each task lifecycle`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-job capability tokens for enhanced task execution control
  * Improved task resumption with automatic token lifecycle management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->