### PR TITLE
fix(config): switch moduleResolution from bundler to node16 [pre-existing]

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "node16",
+    "moduleResolution": "node16",
     "lib": ["ES2022"],
     "outDir": "dist",
     "rootDir": "src",


### PR DESCRIPTION
## **User description**
## Summary

- Fixes a pre-existing TypeScript configuration bug that masked type errors across the entire codebase
- Changes `moduleResolution` from `"bundler"` to `"node16"` and `module` from `"ESNext"` to `"node16"`

## Root Cause

`moduleResolution: "bundler"` is for **frontend bundler tools** (Vite, esbuild, webpack). Zora is a **Node.js CLI application**. Using bundler mode caused TypeScript to silently fail to resolve:
- `node:` protocol imports (`node:crypto`, `node:fs`, `node:path`, etc.)
- Node.js globals (`process`, `setTimeout`, `clearTimeout`, `AbortSignal`, etc.)

...despite `@types/node@22` being correctly installed. The misconfiguration gave agents a false "zero new errors" signal — every implementation PR reported pre-existing errors they couldn't fix.

## Impact

- **Before**: ~50+ spurious type errors across CLI, orchestrator, session-manager, etc.
- **After**: 0 errors (verified on `main` + this branch with full `npx tsc --noEmit`)

## Why No Import Changes Needed

`moduleResolution: "node16"` requires explicit `.js` extensions on relative imports — all imports in the codebase already use `.js` extensions, so no source changes are required beyond `tsconfig.json`.

## Test plan
- [x] `npx tsc --noEmit` reports 0 errors
- [x] All existing source files compile without changes

Should be merged **before** the dead-module integration PRs (#135–#138) so their typecheck results are accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
Fix TypeScript config so Node imports and globals typecheck correctly

### What Changed
- tsconfig updated so Node-specific imports (like node:fs, node:crypto) and Node globals (process, setTimeout, AbortSignal) are recognized by the typechecker
- Eliminates ~50+ spurious type errors that previously appeared across the CLI and related packages; a full typecheck now reports zero errors on main + this branch
- No source code changes required because existing imports already use .js extensions

### Impact
`✅ Fewer false type errors in CI`
`✅ Accurate typecheck results for Node CLI code`
`✅ Shorter developer feedback loops when opening PRs`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
