### PR TITLE
fix(cli): zora-agent ask hangs on exit — node-cron stop() vs destroy()

### DIFF
--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -1463,9 +1463,9 @@ export class Orchestrator {
    * token restrictions on path and command inputs before delegating to the
    * policy engine. Call this once per job to get a closure bound to jobId.
    */
-  private _buildTokenAwareCanUseTool(jobId: string): (tool: string, input: Record<string, unknown>, options: { signal: unknown }) => Promise<{ behavior: 'allow' | 'deny'; message?: string; updatedInput?: Record<string, unknown> }> {
+  private _buildTokenAwareCanUseTool(jobId: string): (tool: string, input: Record<string, unknown>, options: { signal: AbortSignal }) => Promise<{ behavior: 'allow' | 'deny'; message?: string; updatedInput?: Record<string, unknown> }> {
     const policyCanUseTool = this._policyEngine.createCanUseTool();
-    return async (tool: string, input: Record<string, unknown>, options: { signal: unknown }) => {
+    return async (tool: string, input: Record<string, unknown>, options: { signal: AbortSignal }) => {
       const token = this._activeTokens.get(jobId);
       if (token) {
         const pathArg = input['path'] as string | undefined;

--- a/src/routines/heartbeat.ts
+++ b/src/routines/heartbeat.ts
@@ -144,7 +144,9 @@ export class HeartbeatSystem {
    */
   stop(): void {
     if (this._scheduledTask) {
-      this._scheduledTask.stop();
+      // destroy() releases the underlying timer handle so the process can exit.
+      // stop() only pauses the task but keeps the timer alive, preventing exit.
+      this._scheduledTask.destroy();
       this._scheduledTask = null;
     }
   }

--- a/src/routines/routine-manager.ts
+++ b/src/routines/routine-manager.ts
@@ -169,7 +169,9 @@ export class RoutineManager {
    */
   stopAll(): void {
     for (const task of this._scheduledTasks.values()) {
-      task.stop();
+      // destroy() releases the underlying timer handle so the process can exit.
+      // stop() only pauses but keeps the timer alive, preventing process exit.
+      task.destroy();
     }
     this._scheduledTasks.clear();
   }


### PR DESCRIPTION
## **User description**
## Summary

- `HeartbeatSystem.stop()` — `task.stop()` → `task.destroy()`
- `RoutineManager.stopAll()` — `task.stop()` → `task.destroy()`
- `_buildTokenAwareCanUseTool` — `options: { signal: unknown }` → `options: { signal: AbortSignal }`

## Root Cause

`node-cron`'s `task.stop()` **pauses** a scheduled task but keeps the underlying libuv timer handle alive. Node.js cannot exit while active timer handles exist, so the process spun indefinitely after `orchestrator.shutdown()` returned.

`task.destroy()` permanently stops the task and releases the handle, allowing the event loop to drain and the process to exit cleanly.

## Impact

`zora-agent ask "<prompt>"` previously required SIGKILL after delivering its response. After this fix it exits with code 0.

## Reported By

ForwardHorizon — blocking Horizon Wire × Zora integration where `zora-agent ask` is invoked from scripts/launchd as a one-shot OSINT synthesis step.

## Test plan
- [ ] `zora-agent ask "hello"` exits with code 0 after printing response
- [ ] No manual kill required
- [ ] `zora-agent daemon` still runs persistently (shutdown path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety for tool permission handling with consistent type definitions.
  * Enhanced process cleanup mechanism to properly release system resources and allow graceful process termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Stop cron timers so one-shot agent commands exit cleanly

### What Changed
- Scheduled cron tasks are now fully destroyed when stopped, allowing the Node.js process to exit after one-shot commands finish
- Heartbeat and routine schedulers release their timer handles instead of merely pausing, so commands don't hang after shutdown completes
- Tool-call options now accept an AbortSignal type so cancellation signals from the SDK are handled without type mismatch

### Impact
`✅ zora-agent ask exits with code 0 without SIGKILL`
`✅ No hanging background timers after one-shot runs`
`✅ Tool calls accept standard AbortSignal cancellation`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
