### PR TITLE
feat(tools): spawn_zora_agent tool for PM Zora project orchestration

### DIFF
--- a/src/orchestrator/orchestrator.ts
+++ b/src/orchestrator/orchestrator.ts
@@ -1678,11 +1678,11 @@ export class Orchestrator {
     );
 
     // spawn_zora_agent — PM Zora uses this to launch project-scoped child instances
-    const pmProjects = (this._config as unknown as Record<string, unknown>)['pm'] as
-      | { projects?: Array<{ name: string; port: number; icon?: string; color?: string; project_dir: string }> }
+    const pmConfig = (this._config as unknown as Record<string, unknown>)['pm'] as
+      | { projects?: Array<{ name: string; port: number; icon?: string; color?: string; project_dir: string }>; max_children?: number }
       | undefined;
-    const spawnTools: CustomToolDefinition[] = pmProjects?.projects?.length
-      ? [createSpawnZoraTool({ projects: pmProjects.projects, maxChildren: 5 })]
+    const spawnTools: CustomToolDefinition[] = pmConfig?.projects?.length
+      ? [createSpawnZoraTool({ projects: pmConfig.projects, maxChildren: pmConfig.max_children ?? 5 })]
       : [];
 
     return [...permissionTools, ...memoryTools, recallContextTool, ...skillTools, planWorkflowTool, ...subagentTools, ...spawnTools];

--- a/src/orchestrator/tools/spawn-zora-agent.ts
+++ b/src/orchestrator/tools/spawn-zora-agent.ts
@@ -6,18 +6,28 @@
  *
  * Safety constraints:
  * - Max concurrent children enforced via config [pm].max_children (default 5)
- * - Child stdout/stderr → ~/Library/Logs/zora-<project>.log
+ * - Child stdout/stderr → platform log directory / zora-<project>.log
  * - Child PIDs tracked for orphan prevention on PM shutdown
+ * - Per-project spawn lock prevents duplicate launches from concurrent calls
  */
 
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, createWriteStream } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import type { CustomToolDefinition } from '../execution-loop.js';
 import { createLogger } from '../../utils/logger.js';
 
 const log = createLogger('spawn-zora-agent');
+
+/** Platform-appropriate log directory for child Zora instances. */
+function logDir(): string {
+  if (os.platform() === 'darwin') {
+    return path.join(os.homedir(), 'Library', 'Logs');
+  }
+  // Linux / other: use XDG_STATE_HOME or ~/.local/state
+  return process.env['XDG_STATE_HOME'] ?? path.join(os.homedir(), '.local', 'state', 'zora');
+}
 
 export interface ProjectEntry {
   name: string;
@@ -52,28 +62,22 @@ async function isRunning(port: number): Promise<boolean> {
 
 /**
  * Spawn a Zora instance for the given project directory.
+ * Uses the `zora-agent` CLI binary resolved from PATH — no hard-coded paths.
  */
 function spawnZora(project: ProjectEntry, opts: SpawnToolOptions): void {
-  const zoraPath = process.execPath; // node binary
-  const zoraBin = path.resolve(
-    path.dirname(process.argv[1] ?? ''),
-    'zora-agent',
-  );
-
   const projectDir = project.project_dir.replace(/^~/, os.homedir());
-  const logFile = path.join(
-    os.homedir(),
-    'Library',
-    'Logs',
-    `zora-${project.name.toLowerCase()}.log`,
-  );
+  const dir = logDir();
+  const logFile = path.join(dir, `zora-${project.name.toLowerCase()}.log`);
 
-  // Determine config: use project dir's .zora/ if it exists, else fallback
-  const args = ['start', '--project', projectDir, '--no-open'];
+  // Ensure log directory exists
+  mkdirSync(dir, { recursive: true });
 
-  log.info({ project: project.name, port: project.port, args }, '[spawn] Starting child Zora');
+  const logStream = createWriteStream(logFile, { flags: 'a' });
 
-  const child = spawn(zoraPath, [zoraBin, ...args], {
+  log.info({ project: project.name, port: project.port, logFile }, '[spawn] Starting child Zora');
+
+  // Use `zora-agent` from PATH — same binary that started the PM daemon
+  const child = spawn('zora-agent', ['start', '--project', projectDir, '--no-open'], {
     detached: true,
     stdio: ['ignore', 'pipe', 'pipe'],
     env: {
@@ -82,12 +86,8 @@ function spawnZora(project: ProjectEntry, opts: SpawnToolOptions): void {
     },
   });
 
-  // Redirect logs
-  const { createWriteStream } = require('node:fs');
-  const logStream = createWriteStream(logFile, { flags: 'a' });
   child.stdout?.pipe(logStream);
   child.stderr?.pipe(logStream);
-
   child.unref(); // allow parent to exit independently
 
   if (child.pid) {
@@ -101,6 +101,8 @@ function spawnZora(project: ProjectEntry, opts: SpawnToolOptions): void {
 
 export function createSpawnZoraTool(opts: SpawnToolOptions): CustomToolDefinition {
   const activeChildren = new Map<string, number>(); // project name → PID
+  /** Per-project spawn lock — prevents concurrent duplicate launches */
+  const spawning = new Set<string>();
 
   const trackSpawn = (pid: number, project: string) => {
     activeChildren.set(project, pid);
@@ -151,7 +153,7 @@ export function createSpawnZoraTool(opts: SpawnToolOptions): CustomToolDefinitio
         };
       }
 
-      // Check if already running
+      // Check if already running (health check)
       if (await isRunning(project.port)) {
         log.info({ project: projectName, port: project.port }, '[spawn] Already running');
         return {
@@ -161,6 +163,14 @@ export function createSpawnZoraTool(opts: SpawnToolOptions): CustomToolDefinitio
           url: `http://localhost:${project.port}`,
           port: project.port,
           task: task ?? null,
+        };
+      }
+
+      // Per-project spawn lock — prevent duplicate launches from concurrent calls
+      if (spawning.has(project.name)) {
+        return {
+          success: false,
+          error: `Spawn already in progress for "${project.name}" — try again in a moment`,
         };
       }
 
@@ -183,30 +193,36 @@ export function createSpawnZoraTool(opts: SpawnToolOptions): CustomToolDefinitio
         };
       }
 
-      spawnZora(project, { ...opts, onSpawn: trackSpawn, onExit: trackExit });
+      spawning.add(project.name);
+      try {
+        spawnZora(project, { ...opts, onSpawn: trackSpawn, onExit: trackExit });
 
-      // Wait up to 10s for the instance to come up
-      const deadline = Date.now() + 10_000;
-      while (Date.now() < deadline) {
-        await new Promise((r) => setTimeout(r, 500));
-        if (await isRunning(project.port)) {
-          log.info({ project: projectName, port: project.port }, '[spawn] Child Zora ready');
-          return {
-            success: true,
-            status: 'spawned',
-            project: project.name,
-            url: `http://localhost:${project.port}`,
-            port: project.port,
-            task: task ?? null,
-          };
+        // Wait up to 10s for the instance to come up
+        const deadline = Date.now() + 10_000;
+        while (Date.now() < deadline) {
+          await new Promise((r) => setTimeout(r, 500));
+          if (await isRunning(project.port)) {
+            log.info({ project: projectName, port: project.port }, '[spawn] Child Zora ready');
+            return {
+              success: true,
+              status: 'spawned',
+              project: project.name,
+              url: `http://localhost:${project.port}`,
+              port: project.port,
+              task: task ?? null,
+            };
+          }
         }
-      }
 
-      return {
-        success: false,
-        error: `Zora for "${projectName}" did not come up within 10 seconds. Check ~/Library/Logs/zora-${projectName.toLowerCase()}.log`,
-        port: project.port,
-      };
+        const logFile = path.join(logDir(), `zora-${project.name.toLowerCase()}.log`);
+        return {
+          success: false,
+          error: `Zora for "${project.name}" did not come up within 10 seconds. Check ${logFile}`,
+          port: project.port,
+        };
+      } finally {
+        spawning.delete(project.name);
+      }
     },
   };
 }


### PR DESCRIPTION
## **User description**
## Summary
- Adds `spawn_zora_agent` custom tool to the orchestrator tool registry
- PM Zora can invoke it to start project-scoped child Zora instances on demand
- If the target instance is already running (health check on `/api/health`), returns its URL immediately without re-spawning
- Tool is inert on regular Zora instances (only active when `[pm].projects` is defined in config)

## Safety constraints
- Max 5 concurrent children (configurable via `[pm].max_children`)
- Child logs → `~/Library/Logs/zora-<project>.log`
- PID tracking for orphan prevention on PM shutdown
- 10s startup timeout with actionable error message

## Test plan
- [ ] PM Zora config with `[[pm.projects]]` → `spawn_zora_agent` appears in tool list
- [ ] Regular Zora config → tool not present
- [ ] Spawn AgentDev → port 8071 becomes reachable within 10s
- [ ] Spawn already-running instance → returns `already_running` without re-spawning
- [ ] All 1256 unit tests pass

🤖 Generated with Claude Code


___

## **CodeAnt-AI Description**
**Spawn project-scoped child Zora instances from PM Zora**

### What Changed
- PM-configured instances now include a new tool "spawn_zora_agent" that can start a project-scoped child Zora and returns its URL and port.
- If a target project is already running (health check on /api/health), the tool immediately returns status "already_running" and the instance URL without re-spawning.
- The tool enforces a configurable cap on concurrent children (default 5), refuses new spawns when the cap is reached, and reports active projects.
- Spawn failures return clear, actionable errors: unknown project, missing project directory, or a 10‑second startup timeout with a pointer to ~/Library/Logs/zora-<project>.log.
- Child process logs are written to ~/Library/Logs/zora-<project>.log and child PIDs are tracked so PM can manage or detect orphaned children.

### Impact
`✅ Start project-scoped child Zora instances on demand`
`✅ Fewer manual restarts when an instance is already running`
`✅ Clearer spawn failure errors with log location and timeout`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
