### PR TITLE
feat(steering): wire TelegramGateway into daemon boot sequence

### DIFF
--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -33,6 +33,7 @@ import { ApprovalQueue, DEFAULT_APPROVAL_CONFIG } from '../core/approval-queue.j
 import { initGlobalCooldown, DEFAULT_COOLDOWN_CONFIG } from '../core/agent-cooldown.js';
 import { initGlobalForecaster, DEFAULT_FORECASTER_CONFIG } from '../core/memory-risk-forecaster.js';
 import { runSecurityAuditSilent } from './security-commands.js';
+import { TelegramGateway, type TelegramConfig } from '../steering/telegram-gateway.js';
 
 // Allow claude CLI to run as a subprocess even when launched from a Claude Code session.
 // Claude Code sets CLAUDECODE to prevent nesting, but the Zora daemon legitimately
@@ -204,6 +205,43 @@ async function main() {
   });
   agentBusClient.register(); // non-blocking — failure never delays startup
 
+  // Wire TelegramGateway into the steering subsystem (HITL /steer, /status, /approve).
+  // This is separate from TelegramAdapter (ChannelManager general messaging).
+  // Runs daemon-only; skipped in one-shot `ask` mode via the enabled guard.
+  let telegramGateway: TelegramGateway | undefined;
+  const telegramCfg = config.steering.telegram;
+  if (telegramCfg?.enabled) {
+    const token = telegramCfg.bot_token || process.env['TELEGRAM_BOT_TOKEN'];
+    if (!token) {
+      log.warn('steering.telegram.enabled=true but TELEGRAM_BOT_TOKEN is not set — TelegramGateway disabled');
+    } else {
+      try {
+        const gatewayConfig: TelegramConfig = {
+          ...config.steering,
+          bot_token: token,
+          allowed_users: telegramCfg.allowed_users,
+          enabled: true,
+          mode: telegramCfg.mode ?? 'polling',
+          project_dir: projectDir,
+        };
+        telegramGateway = await TelegramGateway.create(
+          gatewayConfig,
+          orchestrator.steeringManager,
+          orchestrator.sessionManager,
+        );
+        // Connect ApprovalQueue so /approve commands reach the gate
+        if (approvalQueue.isEnabled()) {
+          telegramGateway.connectApprovalQueue(approvalQueue);
+          log.info('ApprovalQueue wired to TelegramGateway');
+        }
+        log.info({ allowedUsers: telegramCfg.allowed_users.length }, 'TelegramGateway online (steering HITL)');
+      } catch (err) {
+        log.error({ err: err instanceof Error ? err.message : String(err) }, 'TelegramGateway failed to start — continuing without it');
+        telegramGateway = undefined;
+      }
+    }
+  }
+
   // Start dashboard server
   const dashboard = new DashboardServer({
     providers,
@@ -318,6 +356,10 @@ async function main() {
 
     const graceful = async () => {
       try {
+        if (telegramGateway) {
+          await telegramGateway.stop();
+          telegramGateway = undefined;
+        }
         if (channelManager) {
           await channelManager.stop();
         }

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -208,9 +208,12 @@ async function main() {
   // Wire TelegramGateway into the steering subsystem (HITL /steer, /status, /approve).
   // This is separate from TelegramAdapter (ChannelManager general messaging).
   // Runs daemon-only; skipped in one-shot `ask` mode via the enabled guard.
+  // Skip if channel-policy.toml is present — TelegramAdapter (via ChannelManager) will
+  // handle Telegram in that case; starting both would cause dual long-poll on the same token.
+  const channelPolicyExistsForGateway = fs.existsSync(path.join(configDir, 'config', 'channel-policy.toml'));
   let telegramGateway: TelegramGateway | undefined;
   const telegramCfg = config.steering.telegram;
-  if (telegramCfg?.enabled) {
+  if (telegramCfg?.enabled && !channelPolicyExistsForGateway) {
     const token = telegramCfg.bot_token || process.env['TELEGRAM_BOT_TOKEN'];
     if (!token) {
       log.warn('steering.telegram.enabled=true but TELEGRAM_BOT_TOKEN is not set — TelegramGateway disabled');
@@ -234,7 +237,7 @@ async function main() {
           telegramGateway.connectApprovalQueue(approvalQueue);
           log.info('ApprovalQueue wired to TelegramGateway');
         }
-        log.info({ allowedUsers: telegramCfg.allowed_users.length }, 'TelegramGateway online (steering HITL)');
+        log.info({ allowedUsers: (telegramCfg.allowed_users?.length ?? 0) }, 'TelegramGateway online (steering HITL)');
       } catch (err) {
         log.error({ err: err instanceof Error ? err.message : String(err) }, 'TelegramGateway failed to start — continuing without it');
         telegramGateway = undefined;
@@ -355,11 +358,11 @@ async function main() {
     log.info({ signal }, 'Received signal, shutting down');
 
     const graceful = async () => {
+      if (telegramGateway) {
+        try { await telegramGateway.stop(); } catch (err) { log.warn({ err }, 'Telegram gateway stop error'); }
+        telegramGateway = undefined;
+      }
       try {
-        if (telegramGateway) {
-          await telegramGateway.stop();
-          telegramGateway = undefined;
-        }
         if (channelManager) {
           await channelManager.stop();
         }

--- a/src/steering/index.ts
+++ b/src/steering/index.ts
@@ -6,3 +6,4 @@ export * from './types.js';
 export * from './steering-manager.js';
 export * from './flag-manager.js';
 export * from './steer-injector.js';
+export * from './telegram-gateway.js';

--- a/tests/integration/telegram-gateway-wiring.test.ts
+++ b/tests/integration/telegram-gateway-wiring.test.ts
@@ -1,0 +1,190 @@
+/**
+ * TelegramGateway Wiring Integration Tests
+ *
+ * Verifies that the TelegramGateway is:
+ *   1. Exported from the steering barrel (src/steering/index.ts)
+ *   2. Instantiable and start()-able without a live Telegram connection
+ *   3. Properly wires an ApprovalQueue via connectApprovalQueue()
+ *   4. Provides an idempotent stop() that doesn't throw even when unused
+ *
+ * These tests do NOT make real Telegram connections.  The node-telegram-bot-api
+ * module is mocked to intercept the network boundary.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+import os from 'node:os';
+import fs from 'node:fs/promises';
+
+// ─── Mock the Telegram bot library ────────────────────────────────────────────
+// Must be declared before any imports that transitively pull in the library.
+vi.mock('node-telegram-bot-api', () => {
+  return {
+    default: vi.fn().mockImplementation(() => ({
+      on: vi.fn(),
+      onText: vi.fn(),
+      sendMessage: vi.fn().mockResolvedValue(undefined),
+      stopPolling: vi.fn().mockResolvedValue(undefined),
+    })),
+  };
+});
+
+// ─── Imports (after mock declaration) ────────────────────────────────────────
+import { TelegramGateway } from '../../src/steering/index.js';
+import { SteeringManager } from '../../src/steering/steering-manager.js';
+import { ApprovalQueue, DEFAULT_APPROVAL_CONFIG } from '../../src/core/approval-queue.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+const FAKE_TOKEN = 'fake:bot-token-for-testing';
+const TEST_DIR = path.join(os.tmpdir(), 'zora-tg-wiring-test');
+
+/** Minimal TelegramConfig satisfying the interface */
+const baseTelegramConfig = {
+  enabled: true,
+  bot_token: FAKE_TOKEN,
+  allowed_users: ['123456'],
+  mode: 'polling' as const,
+  // SteeringConfig fields required by TelegramConfig extends SteeringConfig
+  poll_interval: '5s',
+  dashboard_port: 8070,
+  notify_on_flag: false,
+  flag_timeout: '10m',
+  auto_approve_low_risk: false,
+  always_flag_irreversible: false,
+};
+
+async function makeSteeringManager(): Promise<SteeringManager> {
+  try {
+    await fs.rm(TEST_DIR, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+  const sm = new SteeringManager(TEST_DIR);
+  await sm.init();
+  return sm;
+}
+
+// ─── Test suite ───────────────────────────────────────────────────────────────
+
+describe('TelegramGateway barrel export', () => {
+  it('TelegramGateway is exported from steering index', () => {
+    expect(TelegramGateway).toBeDefined();
+    expect(typeof TelegramGateway).toBe('function'); // class is a function
+  });
+
+  it('TelegramGateway has a static create() factory method', () => {
+    expect(typeof TelegramGateway.create).toBe('function');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('TelegramGateway.create() and start()', () => {
+  let sm: SteeringManager;
+  let gateway: TelegramGateway;
+
+  beforeEach(async () => {
+    sm = await makeSteeringManager();
+    gateway = await TelegramGateway.create(baseTelegramConfig as any, sm);
+  });
+
+  afterEach(async () => {
+    // stop() is safe to call on a freshly-created gateway (idempotent guarantee)
+    await gateway.stop();
+  });
+
+  it('creates a gateway instance without throwing', () => {
+    expect(gateway).toBeInstanceOf(TelegramGateway);
+  });
+
+  it('start() — calling create() succeeds with a fake bot_token (no live connection)', () => {
+    // TelegramGateway.create() is the start — it instantiates the bot with polling.
+    // The mock intercepts the network call, so no real Telegram connection is made.
+    // This test proves the creation path through daemon.ts would not throw.
+    expect(gateway).toBeDefined();
+  });
+
+  it('rejects when no bot token is available', async () => {
+    const savedEnv = process.env['TELEGRAM_BOT_TOKEN'];
+    delete process.env['TELEGRAM_BOT_TOKEN'];
+    try {
+      await expect(
+        TelegramGateway.create({ ...baseTelegramConfig, bot_token: undefined } as any, sm)
+      ).rejects.toThrow('TELEGRAM_BOT_TOKEN is required');
+    } finally {
+      if (savedEnv !== undefined) {
+        process.env['TELEGRAM_BOT_TOKEN'] = savedEnv;
+      }
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('TelegramGateway.connectApprovalQueue()', () => {
+  let sm: SteeringManager;
+  let gateway: TelegramGateway;
+  let queue: ApprovalQueue;
+
+  beforeEach(async () => {
+    sm = await makeSteeringManager();
+    gateway = await TelegramGateway.create(baseTelegramConfig as any, sm);
+    queue = new ApprovalQueue({ ...DEFAULT_APPROVAL_CONFIG, enabled: true });
+  });
+
+  afterEach(async () => {
+    await gateway.stop();
+  });
+
+  it('connectApprovalQueue() calls queue.setSendHandler()', () => {
+    const spy = vi.spyOn(queue, 'setSendHandler');
+
+    gateway.connectApprovalQueue(queue);
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('the registered send handler is a function that can be invoked', () => {
+    let capturedHandler: ((msg: string) => Promise<void>) | undefined;
+    vi.spyOn(queue, 'setSendHandler').mockImplementation((fn) => {
+      capturedHandler = fn;
+    });
+
+    gateway.connectApprovalQueue(queue);
+
+    expect(capturedHandler).toBeDefined();
+    // Invoke the handler — with no chatIds registered, it's a no-op (no throw)
+    expect(() => capturedHandler!('test approval message')).not.toThrow();
+  });
+
+  it('connectApprovalQueue() can be called multiple times without throwing', () => {
+    expect(() => {
+      gateway.connectApprovalQueue(queue);
+      gateway.connectApprovalQueue(queue);
+    }).not.toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('TelegramGateway.stop() idempotency', () => {
+  let sm: SteeringManager;
+
+  beforeEach(async () => {
+    sm = await makeSteeringManager();
+  });
+
+  it('stop() does not throw when called without ever starting', async () => {
+    const gateway = await TelegramGateway.create(baseTelegramConfig as any, sm);
+    // Call stop immediately after create, before any polling activity
+    await expect(gateway.stop()).resolves.not.toThrow();
+  });
+
+  it('stop() can be called twice in succession without throwing', async () => {
+    const gateway = await TelegramGateway.create(baseTelegramConfig as any, sm);
+    await expect(gateway.stop()).resolves.not.toThrow();
+    await expect(gateway.stop()).resolves.not.toThrow();
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Winchester Mystery House Audit — Stream E: Telegram Gateway Wiring

`TelegramGateway` lived in `src/steering/` and was exported from the steering index but was never imported or started by the daemon. Telegram configuration (`steering.telegram.*`) was parsed but had zero runtime effect.

### Changes

- **`src/steering/index.ts`**: Added `export * from './telegram-gateway.js'`
- **`src/cli/daemon.ts`**: 
  - Imports `TelegramGateway` from steering index
  - Boot block guarded by `config.steering.telegram.enabled`
  - `bot_token` sourced from `telegramCfg.bot_token || process.env['TELEGRAM_BOT_TOKEN']`
  - `connectApprovalQueue()` called so Telegram can relay human-in-the-loop approval requests
  - `telegramGateway.stop()` called first in graceful shutdown (before orchestrator shutdown)

### Design note
Telegram is initialized after `orchestrator.boot()` completes so it can reference a running orchestrator instance. Shutdown order is reversed (Telegram first) to stop accepting new approvals before the orchestrator tears down.

## Test plan

- [ ] Run `npm test` — pre-existing failures only (performance benchmarks)
- [ ] Set `steering.telegram.enabled: true` + valid `bot_token` → gateway starts
- [ ] Verify `TELEGRAM_BOT_TOKEN` env var is accepted as fallback
- [ ] Verify `steering.telegram.enabled: false` → gateway never instantiated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

## **CodeAnt-AI Description**
**Telegram steering gateway now starts with the daemon and can handle approval requests**

### What Changed
- When Telegram steering is enabled, the daemon now starts the Telegram gateway during boot instead of leaving it inactive.
- If a bot token is not set, the daemon skips Telegram startup and logs a clear warning instead of failing.
- Telegram can now receive approval requests from the approval queue, so `/approve` flows work through Telegram.
- The Telegram gateway is stopped first during shutdown so it stops accepting new requests before the daemon exits.

### Impact
`✅ Telegram steering works after daemon startup`
`✅ Fewer failed approval requests`
`✅ Clearer startup behavior when Telegram is misconfigured`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Telegram steering functionality with `/steer`, `/status`, and `/approve` commands for bot control
  * Introduced configuration-driven control to enable/disable Telegram steering
  * Integrated approval queue support for command processing

* **Tests**
  * Added integration tests for Telegram gateway functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->