### PR TITLE
fix: use MCP-prefixed tool names in memory system prompt

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -229,12 +229,9 @@ const App: React.FC = () => {
     setTaskSteps([]);
 
     try {
-      await axios.post('/api/steer', {
-        jobId: selectedJob,
-        message: prompt,
-        author: 'operator',
-        source: 'dashboard',
-      });
+      // Submit as a new task to the orchestrator (not /api/steer, which is
+      // for injecting mid-flight corrections into already-running tasks)
+      await axios.post('/api/task', { prompt });
     } catch (err) {
       console.error('Task submission failed', err);
       setMessages(prev => [
@@ -379,10 +376,36 @@ const App: React.FC = () => {
         let msgType: Message['type'] = 'agent';
         let content = '';
 
-        if (data.type === 'job_update') {
+        if (data.type === 'done') {
+          // Task completed — the result text was already streamed via 'text' events,
+          // so we only add a message if the agent bubble is missing.
+          const text = data.data?.text ?? '';
+          if (text) {
+            setMessages(prev => {
+              const last = prev[prev.length - 1];
+              if (last?.type === 'agent') return prev; // already shown via text streaming
+              return [...prev, { id: ++messageIdCounter, type: 'agent' as const, content: text, timestamp: new Date() }].slice(-MAX_MESSAGES);
+            });
+          }
+          setTaskRunning(false);
+          return;
+        } else if (data.type === 'task.end') {
+          // Lifecycle marker — clear progress in case 'done' was missed
+          setTaskRunning(false);
+          return;
+        } else if (data.type === 'job_failed') {
+          msgType = 'system';
+          content = `Task failed: ${data.data?.error ?? 'Unknown error'}`;
+          setTaskRunning(false);
+        } else if (data.type === 'task.start') {
+          // Task accepted — already tracking via taskRunning, no visible message needed
+          return;
+        } else if (data.type === 'turn.start' || data.type === 'turn.end') {
+          // Turn lifecycle markers — no visible action needed
+          return;
+        } else if (data.type === 'job_update') {
           msgType = 'system';
           content = `Task ${data.data?.status === 'completed' ? 'completed' : data.data?.status ?? 'update'}`;
-          // Track task completion
           if (data.data?.status === 'completed' || data.data?.status === 'failed') {
             setTaskRunning(false);
           }

--- a/src/memory/memory-manager.ts
+++ b/src/memory/memory-manager.ts
@@ -164,9 +164,12 @@ export class MemoryManager {
       summary += `- Daily notes available (most recent: ${index.mostRecentDailyNote}, total: ${index.dailyNoteCount})\n`;
     }
 
-    summary += `- Use memory_search to find relevant context\n`;
-    summary += `- Use recall_context to read recent daily notes\n`;
-    summary += `- Use memory_save to store new facts\n`;
+    // Tool names must match the MCP-prefixed names registered in execution-loop.ts
+    // (custom tools are served via the 'zora-tools' MCP server)
+    summary += `- Use mcp__zora-tools__memory_search to find relevant context\n`;
+    summary += `- Use mcp__zora-tools__recall_context to read recent daily notes\n`;
+    summary += `- Use mcp__zora-tools__memory_save to store new facts\n`;
+    summary += `- Use mcp__zora-tools__memory_forget to remove outdated or incorrect memories\n`;
     summary += `Only retrieve what you need for this task.`;
 
     parts.push(summary);

--- a/src/providers/claude-provider.ts
+++ b/src/providers/claude-provider.ts
@@ -175,7 +175,12 @@ export class ClaudeProvider implements LLMProvider {
     this._cwd = options.cwd ?? process.cwd();
     this._systemPrompt = options.systemPrompt ?? '';
     this._allowedTools = options.allowedTools ?? [];
-    this._permissionMode = options.permissionMode ?? 'bypassPermissions';
+    // Read permission_mode from provider config, falling back to options, then default.
+    // 'bypassPermissions' fails when running as root in Docker, so containers
+    // should set permission_mode = "acceptEdits" in config.toml.
+    this._permissionMode = config.permission_mode
+      ?? options.permissionMode
+      ?? 'bypassPermissions';
     this._circuitBreaker = new CircuitBreaker();
 
     // Dependency injection: use provided queryFn or lazy-load the real SDK

--- a/src/types.ts
+++ b/src/types.ts
@@ -420,6 +420,9 @@ export interface ClaudeProviderConfig extends BaseProviderConfig {
   type: 'claude-sdk';
   auth_method?: 'mac_session' | 'api_key';
   api_key_env?: string;
+  /** Permission mode for the Claude Code subprocess.
+   *  'bypassPermissions' fails as root in Docker — use 'acceptEdits' instead. */
+  permission_mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan';
 }
 
 /** TYPE-04: Gemini CLI provider config */
@@ -454,6 +457,9 @@ export interface ProviderConfig {
   cli_path?: string;
   api_key_env?: string;
   endpoint?: string;
+  /** Permission mode for the Claude Code subprocess.
+   *  'bypassPermissions' fails as root in Docker — use 'acceptEdits' instead. */
+  permission_mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan';
 }
 
 /** TYPE-04: Typed provider config discriminated union */


### PR DESCRIPTION
## **User description**
## Summary

- System prompt told the agent to use bare tool names (`memory_save`, `memory_search`, `recall_context`) but since `6c34d25`, all custom tools are registered via `createSdkMcpServer()` under the `zora-tools` MCP server — actual names are `mcp__zora-tools__*`
- This caused the agent to fail when users asked it to remember something
- Also adds the previously missing `memory_forget` tool to the prompt instructions

## Test plan

- [x] `npm run test:unit` passes (1317 tests, 1 pre-existing unrelated failure)
- [ ] Deploy to production and verify "remember X" commands invoke `mcp__zora-tools__memory_save` successfully


___

## **CodeAnt-AI Description**
**Send dashboard tasks to the orchestrator and keep memory and Claude settings aligned**

### What Changed
- Dashboard submissions now create a new task instead of sending a steering message to the wrong endpoint.
- The dashboard now clears the running state when tasks finish or fail, and hides lifecycle events that were showing up as noise.
- Memory instructions now use the actual MCP tool names, including the forget action, so the agent can save, search, recall, and remove memories correctly.
- Claude provider settings now respect the configured permission mode, which avoids Docker root permission errors by allowing `acceptEdits`.

### Impact
`✅ Fewer task submission failures`
`✅ Clearer task completion status`
`✅ Reliable memory actions`
`✅ Fewer Docker permission errors`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable permission mode option for Claude provider (supports default, acceptEdits, bypassPermissions, and plan modes).

* **Improvements**
  * Simplified task submission with streamlined API payload structure.
  * Enhanced task lifecycle event handling for improved state tracking during task execution.
  * Updated memory management tool integration with refined naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->