### PR TITLE
fix: dashboard submits to wrong endpoint and doesn't handle completion events

### DIFF
--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -229,12 +229,9 @@ const App: React.FC = () => {
     setTaskSteps([]);
 
     try {
-      await axios.post('/api/steer', {
-        jobId: selectedJob,
-        message: prompt,
-        author: 'operator',
-        source: 'dashboard',
-      });
+      // Submit as a new task to the orchestrator (not /api/steer, which is
+      // for injecting mid-flight corrections into already-running tasks)
+      await axios.post('/api/task', { prompt });
     } catch (err) {
       console.error('Task submission failed', err);
       setMessages(prev => [
@@ -379,10 +376,36 @@ const App: React.FC = () => {
         let msgType: Message['type'] = 'agent';
         let content = '';
 
-        if (data.type === 'job_update') {
+        if (data.type === 'done') {
+          // Task completed — the result text was already streamed via 'text' events,
+          // so we only add a message if the agent bubble is missing.
+          const text = data.data?.text ?? '';
+          if (text) {
+            setMessages(prev => {
+              const last = prev[prev.length - 1];
+              if (last?.type === 'agent') return prev; // already shown via text streaming
+              return [...prev, { id: ++messageIdCounter, type: 'agent' as const, content: text, timestamp: new Date() }].slice(-MAX_MESSAGES);
+            });
+          }
+          setTaskRunning(false);
+          return;
+        } else if (data.type === 'task.end') {
+          // Lifecycle marker — clear progress in case 'done' was missed
+          setTaskRunning(false);
+          return;
+        } else if (data.type === 'job_failed') {
+          msgType = 'system';
+          content = `Task failed: ${data.data?.error ?? 'Unknown error'}`;
+          setTaskRunning(false);
+        } else if (data.type === 'task.start') {
+          // Task accepted — already tracking via taskRunning, no visible message needed
+          return;
+        } else if (data.type === 'turn.start' || data.type === 'turn.end') {
+          // Turn lifecycle markers — no visible action needed
+          return;
+        } else if (data.type === 'job_update') {
           msgType = 'system';
           content = `Task ${data.data?.status === 'completed' ? 'completed' : data.data?.status ?? 'update'}`;
-          // Track task completion
           if (data.data?.status === 'completed' || data.data?.status === 'failed') {
             setTaskRunning(false);
           }

--- a/src/dashboard/frontend/src/App.tsx
+++ b/src/dashboard/frontend/src/App.tsx
@@ -381,10 +381,14 @@ const App: React.FC = () => {
           // so we only add a message if the agent bubble is missing.
           const text = data.data?.text ?? '';
           if (text) {
+            // Capture id and timestamp outside the updater so the function stays pure
+            // (React may call updaters multiple times in Strict Mode / concurrent rendering)
+            const nextId = ++messageIdCounter;
+            const now = new Date();
             setMessages(prev => {
               const last = prev[prev.length - 1];
               if (last?.type === 'agent') return prev; // already shown via text streaming
-              return [...prev, { id: ++messageIdCounter, type: 'agent' as const, content: text, timestamp: new Date() }].slice(-MAX_MESSAGES);
+              return [...prev, { id: nextId, type: 'agent' as const, content: text, timestamp: now }].slice(-MAX_MESSAGES);
             });
           }
           setTaskRunning(false);


### PR DESCRIPTION
## Summary

Fixes #167.

Two bugs in the dashboard frontend that prevent task submission and completion from working end-to-end:

1. **Wrong submission endpoint** — chat messages were sent to `POST /api/steer` (mid-flight steering for already-running tasks) instead of `POST /api/task` (submits a new task to the orchestrator). Since no task was running with the default `jobId`, messages were written to a file on disk that nothing read.

2. **SSE completion events never handled** — the event handler only cleared the "Working..." state on `job_update` events, which the backend never emits during normal task completion. Added handlers for `done`, `task.end`, and `job_failed` — the actual event types the orchestrator emits — so the spinner clears and responses appear correctly.

Also suppresses `task.start`, `turn.start`, and `turn.end` lifecycle events from creating noise as system messages in the chat.

## Changes

- Replace `POST /api/steer` with `POST /api/task` for new task submission
- Add SSE handlers for `done`, `task.end`, `job_failed`, `task.start`, `turn.start`, `turn.end`

## Testing

- [x] Manual: submit a task from the dashboard chat input — response appears, spinner clears after completion
- [x] Manual: verify `job_failed` shows an error message in the chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified task submission to send only the prompt for cleaner handling.
  * Improved real-time status processing to be more reliable and responsive.

* **Bug Fixes**
  * Prevents duplicate assistant messages at task completion.
  * Ensures task completion/failure reliably stops progress indicators and surfaces a clear "Task failed" system message when appropriate.
  * Suppresses internal start/turn events from appearing to users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->