### PR TITLE
fix: allow permission_mode to be configured in config.toml for Claude provider

### DIFF
--- a/src/providers/claude-provider.ts
+++ b/src/providers/claude-provider.ts
@@ -175,7 +175,12 @@ export class ClaudeProvider implements LLMProvider {
     this._cwd = options.cwd ?? process.cwd();
     this._systemPrompt = options.systemPrompt ?? '';
     this._allowedTools = options.allowedTools ?? [];
-    this._permissionMode = options.permissionMode ?? 'bypassPermissions';
+    // Read permission_mode from provider config, falling back to options, then default.
+    // 'bypassPermissions' fails when running as root in Docker, so containers
+    // should set permission_mode = "acceptEdits" in config.toml.
+    this._permissionMode = config.permission_mode
+      ?? options.permissionMode
+      ?? 'bypassPermissions';
     this._circuitBreaker = new CircuitBreaker();
 
     // Dependency injection: use provided queryFn or lazy-load the real SDK

--- a/src/types.ts
+++ b/src/types.ts
@@ -420,6 +420,9 @@ export interface ClaudeProviderConfig extends BaseProviderConfig {
   type: 'claude-sdk';
   auth_method?: 'mac_session' | 'api_key';
   api_key_env?: string;
+  /** Permission mode for the Claude Code subprocess.
+   *  'bypassPermissions' fails as root in Docker — use 'acceptEdits' instead. */
+  permission_mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan';
 }
 
 /** TYPE-04: Gemini CLI provider config */
@@ -454,6 +457,9 @@ export interface ProviderConfig {
   cli_path?: string;
   api_key_env?: string;
   endpoint?: string;
+  /** Permission mode for the Claude Code subprocess.
+   *  'bypassPermissions' fails as root in Docker — use 'acceptEdits' instead. */
+  permission_mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan';
 }
 
 /** TYPE-04: Typed provider config discriminated union */


### PR DESCRIPTION
## Summary

Fixes https://github.com/ryaker/zora/issues/166.

The Claude provider hardcodes `permissionMode` to `'bypassPermissions'`, which becomes `--dangerously-skip-permissions` when spawning the Claude Code subprocess. That flag is rejected when running as root (the Docker default):

```
--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
```

This adds an optional `permission_mode` field to the provider config, letting container deployments use `acceptEdits` instead. Existing configs without the field are unaffected — the fallback chain preserves `'bypassPermissions'` as the default.

## Changes

- **`src/types.ts`** — adds `permission_mode?: 'default' | 'acceptEdits' | 'bypassPermissions' | 'plan'` to `ClaudeProviderConfig` and `ProviderConfig`
- **`src/providers/claude-provider.ts`** — reads `config.permission_mode` in the constructor before falling back to `options.permissionMode` then `'bypassPermissions'`

Example config for Docker:
```toml
[[providers]]
name = "claude"
type = "claude-sdk"
permission_mode = "acceptEdits"
```

## Testing

- [x] Verified end-to-end in Docker with `permission_mode = "acceptEdits"`: Claude provider spawns, executes tasks, policy enforcement and audit logging work correctly
- [x] Existing configs without `permission_mode` behave identically (fallback to `'bypassPermissions'`)